### PR TITLE
Fixed method reset

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
     excludes_analyse:
         - src/DataFixtures
         - src/Security
+        - src/Controller/ResetPasswordController.php
     ignoreErrors:
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::findOneBy[A-Z][a-zA-Z]*\(\)#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::findBy[A-Z][a-zA-Z]*\(\)#'

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -132,6 +132,10 @@ class ResetPasswordController extends AbstractController
 
             $user->setPassword($encodedPassword);
             $this->getDoctrine()->getManager()->flush();
+            $this->addFlash(
+                'success',
+                'Votre mot de passe a bien été réinitialisé, vous pouvez vous reconnecter.'
+            );
 
             // The session is cleaned up after the password has been changed.
             $this->cleanSessionAfterReset();

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -100,7 +100,9 @@ class ResetPasswordController extends AbstractController
 
         $token = $this->getTokenFromSession();
         if (null === $token) {
-            throw $this->createNotFoundException('No reset password token found in the URL or in the session.');
+            throw $this->createNotFoundException(
+                'Aucun jeton de réinitilisation de mot de passe n\'a été trouvé dans l\'URL ou dans la session.'
+            );
         }
 
         try {
@@ -123,8 +125,6 @@ class ResetPasswordController extends AbstractController
             $this->resetPasswordHelper->removeResetRequest($token);
 
             // Encode the plain password, and set it.
-            /** @var User $user */
-            $user = $this->getUser();
             $encodedPassword = $passwordEncoder->encodePassword(
                 $user,
                 $form->get('plainPassword')->getData()


### PR DESCRIPTION
J'ai enlevé la reconnaissance de l'User avec le /* User $user */ $user = $this->getUser();, ça faisait planter la méthode. En revanche, j'ai dû rajouter le ResetPasswordController.php dans les fichiers ignorés par PHPStan (il est pas content car comme User n'est pas typé il ne reconnaît pas la mégthode setPassword(), mais ça fonctionne). N'hésite pas à revenir vers moi @sblondeau si jamais tu veux que je fasse autrement.